### PR TITLE
fix(validator): allow `serverIPAddress` to be an empty string

### DIFF
--- a/packages/validator/src/schemas/har/v1.2.json
+++ b/packages/validator/src/schemas/har/v1.2.json
@@ -115,11 +115,7 @@
         "cache": { "$ref": "#/definitions/cache" },
         "timings": { "$ref": "#/definitions/timings" },
         "serverIPAddress": {
-          "type": "string",
-          "if": { "format": "ipv4" },
-          "else": {
-            "format": "ipv6"
-          }
+          "type": "string"
         },
         "connection": {
           "type": "string"

--- a/packages/validator/tests/fixtures/har.invalid-server-ip.json
+++ b/packages/validator/tests/fixtures/har.invalid-server-ip.json
@@ -1,0 +1,94 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "entries": [
+      {
+        "cache": {},
+        "connection": "125554",
+        "request": {
+          "method": "GET",
+          "url": "https://brokencrystals.neuralegion.com/",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Host",
+              "value": "brokencrystals.neuralegion.com"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 1305,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Server",
+              "value": "nginx/1.19.8"
+            },
+            {
+              "name": "Date",
+              "value": "Mon, 18 Oct 2021 09:51:50 GMT"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/html"
+            },
+            {
+              "name": "Content-Length",
+              "value": "7465"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Wed, 13 Oct 2021 12:12:15 GMT"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "ETag",
+              "value": "\"6166cd1f-1d29\""
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 7465,
+            "mimeType": "text/html",
+            "compression": 0
+          },
+          "redirectURL": "",
+          "headersSize": 240,
+          "bodySize": 7465
+        },
+        "serverIPAddress": "1.1.1.1000",
+        "startedDateTime": "2021-10-18T09:51:49.609Z",
+        "time": 853.6939999903552,
+        "timings": {
+          "blocked": 3.432999976212159,
+          "dns": 0,
+          "ssl": 283.47700000000003,
+          "connect": 566.048,
+          "send": 0.1069999999999709,
+          "wait": 283.5960000015609,
+          "receive": 0.510000012582168
+        }
+      }
+    ]
+  }
+}

--- a/packages/validator/tests/fixtures/har.missed-server-ip.json
+++ b/packages/validator/tests/fixtures/har.missed-server-ip.json
@@ -1,0 +1,94 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "entries": [
+      {
+        "cache": {},
+        "connection": "125554",
+        "request": {
+          "method": "GET",
+          "url": "https://brokencrystals.neuralegion.com/",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Host",
+              "value": "brokencrystals.neuralegion.com"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 1305,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Server",
+              "value": "nginx/1.19.8"
+            },
+            {
+              "name": "Date",
+              "value": "Mon, 18 Oct 2021 09:51:50 GMT"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/html"
+            },
+            {
+              "name": "Content-Length",
+              "value": "7465"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Wed, 13 Oct 2021 12:12:15 GMT"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "ETag",
+              "value": "\"6166cd1f-1d29\""
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 7465,
+            "mimeType": "text/html",
+            "compression": 0
+          },
+          "redirectURL": "",
+          "headersSize": 240,
+          "bodySize": 7465
+        },
+        "serverIPAddress": "",
+        "startedDateTime": "2021-10-18T09:51:49.609Z",
+        "time": 853.6939999903552,
+        "timings": {
+          "blocked": 3.432999976212159,
+          "dns": 0,
+          "ssl": 283.47700000000003,
+          "connect": 566.048,
+          "send": 0.1069999999999709,
+          "wait": 283.5960000015609,
+          "receive": 0.510000012582168
+        }
+      }
+    ]
+  }
+}

--- a/packages/validator/tests/har.spec.ts
+++ b/packages/validator/tests/har.spec.ts
@@ -1,6 +1,8 @@
 import 'chai/register-should';
 import validJson from './fixtures/har.valid.json';
 import missedCookieName from './fixtures/har.missed-cookie-name.json';
+import missedServerIP from './fixtures/har.missed-server-ip.json';
+import invalidServerIP from './fixtures/har.invalid-server-ip.json';
 import wrongMethodValueHar from './fixtures/har.wrong-method-value.json';
 import { HarValidator } from '../src';
 import { ErrorObject } from 'ajv';
@@ -19,6 +21,37 @@ describe('HarValidator', () => {
 
       // assert
       result.should.be.empty;
+    });
+
+    it('should successfully validate HAR if server IP is missed', async () => {
+      // arrange
+      const input = missedServerIP as unknown as Har;
+
+      // act
+      const result = await validator.verify(input);
+
+      // assert
+      result.should.be.empty;
+    });
+
+    it.skip('should return error if server IP is not valid IP address', async () => {
+      // arrange
+      const input = invalidServerIP as unknown as Har;
+      const expected: ErrorObject[] = [
+        {
+          instancePath: '/log/entries/0/serverIPAddress',
+          schemaPath: '#/properties/serverIPAddress/else/else/format',
+          keyword: 'format',
+          params: { format: 'ipv4' },
+          message: 'must match format "ipv4"'
+        }
+      ];
+
+      // act
+      const result = await validator.verify(input);
+
+      // assert
+      result.should.deep.eq(expected);
     });
 
     it('should return error if entries are empty', async () => {


### PR DESCRIPTION
Once the condenser is fixed we will be able to revert a schema to use the conditional keywords:
```json
"if": {
  "const": ""
},
"else": {
  "if": {
    "format": "ipv6"
  },
  "else": {
    "format": "ipv4"
  }
}
```

closes #60