### PR TITLE
fix(postman): skip mime-type detection in dry run mode

### DIFF
--- a/packages/postman/src/converter/DefaultConverter.ts
+++ b/packages/postman/src/converter/DefaultConverter.ts
@@ -20,11 +20,13 @@ export enum AuthLocation {
 
 export class DefaultConverter implements Converter {
   private readonly variables: ReadonlyArray<Postman.Variable>;
+  private readonly dryRun: boolean;
 
   constructor(
     private readonly parserFactory: VariableParserFactory,
     options: {
       environment?: Record<string, string>;
+      dryRun?: boolean;
     }
   ) {
     this.variables = Object.entries(options.environment ?? {}).map(
@@ -33,6 +35,7 @@ export class DefaultConverter implements Converter {
         value
       })
     );
+    this.dryRun = !!options.dryRun;
   }
 
   public async convert(collection: Postman.Document): Promise<Request[]> {
@@ -306,7 +309,8 @@ export class DefaultConverter implements Converter {
               : fileName;
 
             const contentType: string | undefined =
-              x.contentType ?? (lookup(extension ?? '') || undefined);
+              x.contentType ??
+              (this.dryRun ? undefined : lookup(extension ?? '') || undefined);
 
             return {
               fileName,

--- a/packages/postman/tests/fixtures/Salesforce APIs.postman_collection.json
+++ b/packages/postman/tests/fixtures/Salesforce APIs.postman_collection.json
@@ -2339,7 +2339,8 @@
                     {
                       "key": "fileUpload",
                       "type": "file",
-                      "src": []
+                      "contentType": "image/jpeg",
+                      "src": "photo.jpg"
                     }
                   ]
                 },

--- a/packages/postman/tests/fixtures/Salesforce APIs.postman_collection.result.json
+++ b/packages/postman/tests/fixtures/Salesforce APIs.postman_collection.result.json
@@ -1277,7 +1277,8 @@
           "value": "{\"cropY\":\"0\",\"cropX\":\"0\",\"cropSize\":\"200\"}"
         },
         {
-          "fileName": "",
+          "fileName": "photo.jpg",
+          "contentType": "image/jpeg",
           "name": "fileUpload",
           "value": ""
         }


### PR DESCRIPTION
- currently mime-db dependency adds almost 200kb to bundle size

fixes #70