### PR TITLE
ci: pin `npm` to v8.3.1

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.14.0]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: 14
 
       - id: npm-cache-dir-path
         run: echo "::set-output name=dir::$(npm config get cache)"


### PR DESCRIPTION
See details in https://github.com/npm/cli/issues/4660