### PR TITLE
ci: expose `CC_TEST_REPORTER_ID`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,14 +23,6 @@ checks:
   return-statements:
     config:
       threshold: 4
-plugins:
-  eslint:
-    enabled: true
-    channel: 'eslint-7'
-    config:
-      config: ./.eslintrc.js
-      extensions:
-        - .ts
 exclude_patterns:
   - '**/dist/'
   - '**/node_modules/'

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -65,12 +65,12 @@ jobs:
       - run: npm run build
       - run: npm run coverage:all
 
-      - uses: paambaati/codeclimate-action@v2.7.5
+      - uses: paambaati/codeclimate-action@v3.0.0
+        if: ${{ hashFiles('.coverage/lcov.info') }}
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          CC_TEST_REPORTER_ID: 8f03df35249169ee1488314f32a347bf3eba5ad0decfa9b999d04f74df71b415
         with:
           coverageLocations: .coverage/lcov.info:lcov
-          debug: true
 
   release:
     if: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
In [GitHub Action](https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow), secrets are only exposed on `push` from a branch of the same repo. It makes it impossible to publish a coverage report.

As stated in the [codeclimate documentation](https://docs.codeclimate.com/docs/finding-your-test-coverage-token#should-i-keep-my-test-reporter-id-secret) `CC_TEST_REPORTER_ID` can't be considered as a secret.