### PR TITLE
fix(openapi-sampler): check for circular references in schema objects

### DIFF
--- a/packages/oas/tests/DefaultConverter.spec.ts
+++ b/packages/oas/tests/DefaultConverter.spec.ts
@@ -90,6 +90,11 @@ describe('DefaultConverter', () => {
         input: 'params-body-default.oas.yaml',
         expected: 'params-body-default.oas.result.json',
         message: 'should correctly use default value for oas body'
+      },
+      {
+        input: 'circular-refs.swagger.yaml',
+        expected: 'circular-refs.swagger.result.json',
+        message: 'should correctly handle circular references'
       }
     ].forEach(({ input: inputFile, expected: expectedFile, message }) => {
       it(message, async () => {

--- a/packages/oas/tests/fixtures/circular-refs.swagger.result.json
+++ b/packages/oas/tests/fixtures/circular-refs.swagger.result.json
@@ -1,0 +1,45 @@
+[
+  {
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+      {
+        "name": "accept",
+        "value": "application/json"
+      }
+    ],
+    "headersSize": 0,
+    "httpVersion": "HTTP/1.1",
+    "method": "GET",
+    "queryString": [],
+    "url": "https://petstore.swagger.io/pets"
+  },
+  {
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+      {
+        "name": "content-type",
+        "value": "application/json"
+      },
+      {
+        "name": "api_key",
+        "value": ""
+      }
+    ],
+    "headersSize": 0,
+    "httpVersion": "HTTP/1.1",
+    "method": "PUT",
+    "postData": {
+      "mimeType": "application/json",
+      "text": "{\"id\":42,\"name\":\"lorem\",\"subCategories\":[{\"id\":42,\"name\":\"lorem\",\"subCategories\":[]}]}"
+    },
+    "queryString": [
+      {
+        "name": "dummy",
+        "value": ""
+      }
+    ],
+    "url": "https://petstore.swagger.io/store/order/?dummy="
+  }
+]

--- a/packages/oas/tests/fixtures/circular-refs.swagger.yaml
+++ b/packages/oas/tests/fixtures/circular-refs.swagger.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.1
+info:
+  title: Swagger Petstore
+  version: 1.0.0
+servers:
+  - url: https://petstore.swagger.io
+paths:
+  /pets:
+    get:
+      responses:
+        200:
+          description: Dummy
+          content:
+            application/json:
+              schema: {}
+  /store/order/{orderId}:
+    put:
+      parameters:
+        - in: path
+          required: true
+          name: orderId
+          schema: {}
+        - in: query
+          name: dummy
+          schema: {}
+        - in: header
+          name: api_key
+          schema: {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Category'
+      responses:
+        200:
+          description: successful operation
+components:
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        subCategories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'
+      xml:
+        name: Category

--- a/packages/openapi-sampler/README.md
+++ b/packages/openapi-sampler/README.md
@@ -58,6 +58,8 @@ import { sample } from '@har-sdk/openapi-sampler';
     Don't include `writeOnly` object properties
   - **quiet** - `boolean`
     Don't log console warning messages
+  - **maxSampleDepth** - `number`
+    Specifies the maximum safe depth of the sampling stack.
 - **spec** - whole specification where the schema is taken from. Required only when schema may contain `$ref`. **spec** must not contain any external references
 
 ## Example

--- a/packages/openapi-sampler/src/index.ts
+++ b/packages/openapi-sampler/src/index.ts
@@ -16,7 +16,11 @@ export const sample = (
   options?: Options,
   spec?: Specification
 ): any | undefined => {
-  const opts = Object.assign({}, { skipReadOnly: false }, options);
+  const opts = Object.assign(
+    {},
+    { skipReadOnly: false, maxSampleDepth: 1 },
+    options
+  );
 
   const traverse = new DefaultTraverse();
 

--- a/packages/openapi-sampler/src/traverse/Traverse.ts
+++ b/packages/openapi-sampler/src/traverse/Traverse.ts
@@ -5,6 +5,7 @@ export interface Options {
   skipWriteOnly?: boolean;
   skipNonRequired?: boolean;
   quiet?: boolean;
+  maxSampleDepth?: number;
 }
 
 export interface Sample {

--- a/packages/openapi-sampler/src/utils.ts
+++ b/packages/openapi-sampler/src/utils.ts
@@ -23,3 +23,7 @@ export const mergeDeep = (
   );
 
 export const firstArrayElement = <T>(x: T[]): T | undefined => x[0];
+
+export const getReplacementForCircular = (type: string) => ({
+  value: type === 'object' ? {} : type === 'array' ? [] : undefined
+});

--- a/packages/openapi-sampler/tests/traverse.spec.ts
+++ b/packages/openapi-sampler/tests/traverse.spec.ts
@@ -1,0 +1,146 @@
+import { sample, Specification } from '../src';
+
+describe('traverse', () => {
+  it('should not follow circular references in schema objects', () => {
+    const schema: {
+      type: string;
+      properties: Record<string, unknown>;
+    } = {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string',
+          default: 'bar'
+        }
+      }
+    };
+    schema.properties.baz = schema;
+    const expected = {
+      foo: 'bar',
+      baz: {
+        foo: 'bar',
+        baz: {}
+      }
+    };
+
+    const result = sample(schema);
+    expect(result).toEqual(expected);
+  });
+
+  it('should not follow circular references when more that one circular reference present', () => {
+    const schema: {
+      type: string;
+      properties: Record<string, unknown>;
+    } = {
+      type: 'object',
+      properties: {}
+    };
+
+    schema.properties.foo = schema;
+    schema.properties.baz = schema;
+
+    const expected = {
+      foo: {
+        foo: {},
+        baz: {}
+      },
+      baz: {
+        foo: {},
+        baz: {}
+      }
+    };
+
+    const result = sample(schema);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should not detect false-positive circular references', () => {
+    const a = {
+      type: 'string',
+      example: 'test'
+    };
+
+    const b = {
+      type: 'integer',
+      example: 1
+    };
+
+    const c = {
+      type: 'object',
+      properties: {
+        test: {
+          type: 'string'
+        }
+      }
+    };
+
+    const d = {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    };
+
+    const e = {
+      allOf: [c, c]
+    };
+
+    const f = {
+      oneOf: [d, d]
+    };
+
+    const g = {
+      anyOf: [c, c]
+    };
+
+    const h = { $ref: '#/components/schemas/a' };
+
+    const nonCircularSchema = {
+      type: 'object',
+      properties: {
+        a,
+        aa: a,
+        b,
+        bb: b,
+        c,
+        cc: c,
+        d,
+        dd: d,
+        e,
+        ee: e,
+        f,
+        ff: f,
+        g,
+        gg: g,
+        h,
+        hh: h
+      }
+    };
+
+    const expected = {
+      a: 'test',
+      aa: 'test',
+      b: 1,
+      bb: 1,
+      c: { test: 'lorem' },
+      cc: { test: 'lorem' },
+      d: ['lorem'],
+      dd: ['lorem'],
+      e: { test: 'lorem' },
+      ee: { test: 'lorem' },
+      f: ['lorem'],
+      ff: ['lorem'],
+      g: { test: 'lorem' },
+      gg: { test: 'lorem' },
+      h: 'test',
+      hh: 'test'
+    };
+
+    const result = sample(nonCircularSchema, {}, {
+      components: { schemas: { a, nonCircularSchema } }
+    } as unknown as Specification);
+
+    expect(result).toEqual(expected);
+  });
+});


### PR DESCRIPTION
closes #157
based-on: Redocly/openapi-sampler#115